### PR TITLE
Update chamfer_distance.cpp forward declarations to void to be consis…

### DIFF
--- a/chamfer_distance/chamfer_distance.cpp
+++ b/chamfer_distance/chamfer_distance.cpp
@@ -1,7 +1,7 @@
 #include <torch/torch.h>
 
 // CUDA forward declarations
-int ChamferDistanceKernelLauncher(
+void ChamferDistanceKernelLauncher(
     const int b, const int n,
     const float* xyz,
     const int m,
@@ -11,7 +11,7 @@ int ChamferDistanceKernelLauncher(
     float* result2,
     int* result2_i);
 
-int ChamferDistanceGradKernelLauncher(
+void ChamferDistanceGradKernelLauncher(
     const int b, const int n,
     const float* xyz1,
     const int m,


### PR DESCRIPTION
…tent with chamfer_distance.cu definitions.

This is to fix: cd.pyd : ``fatal error LNK1120: 2 unresolved externals``

and

``chamfer_distance.o : error LNK2019: unresolved external symbol "int __cdecl ChamferDistanceGradKernelLauncher(int,int,float const *,int,float const *,float const *,int const *,float const *,int const *,float *,float *)" (?ChamferDistanceGradKernelLauncher@@YAHHHPEBMH00PEBH01PEAM2@Z) referenced in function "void __cdecl chamfer_distance_backward_cuda(class at::Tensor,class at::Tensor,class at::Tensor,class at::Tensor,class at::Tensor,class at::Tensor,class at::Tensor,class at::Tensor)" (?chamfer_distance_backward_cuda@@YAXVTensor@at@@0V12@11111@Z)
  Hint on symbols that are defined and could potentially match:
    "void __cdecl ChamferDistanceGradKernelLauncher(int,int,float const *,int,float const *,float const *,int const *,float const *,int const *,float *,float *)" (?ChamferDistanceGradKernelLauncher@@YAXHHPEBMH00PEBH01PEAM2@Z)``

and 

``chamfer_distance.o : error LNK2019: unresolved external symbol "int __cdecl ChamferDistanceKernelLauncher(int,int,float const *,int,float const *,float *,int *,float *,int *)" (?ChamferDistanceKernelLauncher@@YAHHHPEBMH0PEAMPEAH12@Z) referenced in function "void __cdecl chamfer_distance_forward_cuda(class at::Tensor,class at::Tensor,class at::Tensor,class at::Tensor,class at::Tensor,class at::Tensor)" (?chamfer_distance_forward_cuda@@YAXVTensor@at@@00000@Z)
  Hint on symbols that are defined and could potentially match:
    "void __cdecl ChamferDistanceKernelLauncher(int,int,float const *,int,float const *,float *,int *,float *,int *)" (?ChamferDistanceKernelLauncher@@YAXHHPEBMH0PEAMPEAH12@Z)``

linker errors