### PR TITLE
Set absolute paths for chamfer_distance.cpp/.cu

### DIFF
--- a/chamfer_distance/chamfer_distance.py
+++ b/chamfer_distance/chamfer_distance.py
@@ -1,10 +1,12 @@
 
 import torch
+import os
+script_path = os.path.dirname(os.path.abspath(__file__))
 
 from torch.utils.cpp_extension import load
 cd = load(name="cd",
-          sources=["chamfer_distance/chamfer_distance.cpp",
-                   "chamfer_distance/chamfer_distance.cu"])
+          sources=[os.path.join(script_path,"chamfer_distance.cpp"),
+                   os.path.join(script_path,"chamfer_distance.cu")])
 
 class ChamferDistanceFunction(torch.autograd.Function):
     @staticmethod


### PR DESCRIPTION
Hi, 

When importing the package from a parent directory `my_repo/pyTorchChamferDistance/chamfer_distance` (I'm using it as a git submodule) I get the error:
```bash
FileNotFoundError: [Errno 2] No such file or directory: 'chamfer_distance/chamfer_distance.cpp'
```
because the script "chamfer_distace.py" tries a relative import of the sources `chamfer_distance.cpp/.cu`.

<br>

I fixed the `sources` paths in `chamfer_distance.py` to be absolute, and ca be loaded from anywhere.  Then, I can do:
```bash
export PYTHONPATH="${PYTHONPATH}:/my-repo/pyTorchChamferDistance"
```
after which the package can normally import with:
```python
from chamfer_distance import ChamferDistance
```